### PR TITLE
actionlog plugin - Class 'ArrayHelper' not found

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('ActionlogsHelper', JPATH_ADMINISTRATOR . '/components/com_actionlogs/helpers/actionlogs.php');
 


### PR DESCRIPTION
fixes the error message "Class 'ArrayHelper' not found" when deleting any content (menu item, article, category...)

### Summary of Changes
import Joomla\Utilities\ArrayHelper in ./plugins/actionlog/joomla/joomla.php

